### PR TITLE
Catch OutOfMemoryError and set imageView GONE

### DIFF
--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/slide/SimpleSlide.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/slide/SimpleSlide.java
@@ -527,7 +527,11 @@ public class SimpleSlide implements Slide, RestorableSlide, ButtonCtaSlide {
             //Image
             if (imageView != null) {
                 if (imageRes != 0) {
-                    imageView.setImageResource(imageRes);
+                    try {
+                        imageView.setImageResource(imageRes);
+                    } catch (OutOfMemoryError oome) {
+                        imageView.setVisibility(View.GONE);
+                    }
                     imageView.setVisibility(View.VISIBLE);
                 } else {
                     imageView.setVisibility(View.GONE);


### PR DESCRIPTION
On a few devices, I've received an OutOfMemoryError exception crashing the app when setting the ImageResource.
Porposing to catch the out of memory exception and hiding the image rather than crashing the device.