### PR TITLE
Handle NullPointerException with updateButtonNextDrawable

### DIFF
--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroActivity.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroActivity.java
@@ -916,6 +916,8 @@ public class IntroActivity extends AppCompatActivity implements IntroNavigation 
     }
 
     private void updateButtonNextDrawable() {
+        if (adapter == null) return;
+
         float realPosition = position + positionOffset;
         float offset = 0;
 


### PR DESCRIPTION
If the adapter is null, exit the function rather than crash

Last 30 days have had 17 unique device crashes due to a NullPointerException on line:
`if (realPosition >= adapter.getCount() - 1) {`

![image](https://user-images.githubusercontent.com/208641/33226246-2c141110-d13e-11e7-90f5-47518091cceb.png)